### PR TITLE
Migrate parser from pest to regex implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md
+
+## Introduction
+Yggit is a specialized tool designed to support a "stacked commit" git workflow. It streamlines the process of creating layered commits, improving review efficiency and maintaining a clear commit history.
+
+## Repository Structure
+The repository is organized to facilitate clear separation of concerns:
+
+- **Cargo Files**
+  - `Cargo.toml` and `Cargo.lock`: Define project dependencies and configurations for this Rust project.
+  
+- **Source Code (`src/`)**
+  - **Core Functionality:**  
+    - `src/core.rs`: Contains the fundamental implementations of Yggit.
+  - **Commands:**  
+    - `src/commands/`: Houses command implementations such as `push.rs` and `show.rs`.
+  - **Git Integration:**  
+    - `src/git/`: Contains modules for git operations including `git.rs` and `config.rs`.
+  - **Parsing:**  
+    - `src/parser/`: Includes grammar definitions (e.g., `yggit.pest`) and parsing logic.
+    
+- **Editor Integration (`editor/`)**
+  - **Neovim Integration:**
+    - Files under `editor/nvim/` provide integration support.
+    - See `editor/nvim/install.md` for installation and usage instructions.
+
+- **Documentation**
+  - `README.md`: Offers general information about the project.
+  - This file (AGENTS.md) provides a detailed guide for future contributors.
+
+## Development Workflow
+To work effectively with Yggit, follow these steps:
+
+- **Building the Project:**  
+  Use `cargo build` to compile the project.
+
+- **Running the Application:**  
+  Execute with `cargo run -- [arguments]` as necessary.
+
+- **Testing:**  
+  Run tests using `cargo test` to ensure code reliability.
+
+- **Code Quality:**  
+  Format your code with `cargo fmt` and check for linting issues using `cargo clippy`.
+
+## The Stacked Commit Workflow
+Yggit implements a "stacked commit" strategy to improve collaboration and code management:
+
+- **Commit Layering:**  
+  Each change is isolated into separate commits, making code review simpler and history cleaner.
+
+- **Key Commands:**  
+  Refer to `src/commands/push.rs` for details on how push operations are handled within this workflow.
+
+- **Best Practices:**  
+  - Keep commits small and focused.
+  - Use descriptive commit messages.
+  - Regularly review commit stacks to maintain clarity.
+
+## Editor Integration
+Yggit comes with dedicated support for Neovim:
+
+- **Setup:**  
+  Follow the instructions in `editor/nvim/install.md` to install and configure Neovim integration.
+
+- **Usage:**  
+  Ensure your editor is configured to work with Yggit's features. Additional integrations may be added in the future.
+
+## Contribution Guidelines and Testing
+To maintain high-quality contributions:
+
+- **Testing:**  
+  Run `cargo test` before pushing changes.
+
+- **Formatting and Linting:**  
+  Always run `cargo fmt` and `cargo clippy` to ensure code consistency and quality.
+
+- **Documentation Updates:**  
+  Update AGENTS.md and README.md when new processes or features are introduced.
+
+- **General Best Practices:**  
+  - Follow the stacked commit workflow diligently.
+  - Keep code changes isolated.
+  - Maintain clear, descriptive commit messages and update the documentation as necessary.
+
+---
+
+This guide is intended to ensure that future contributors have everything they need to work efficiently on the Yggit repo. Stay updated with any repository changes and contribute to ongoing improvements.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,15 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,35 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,16 +171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -334,15 +295,9 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "openssl-probe"
@@ -373,51 +328,6 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
-
-[[package]]
-name = "pest"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "pkg-config"
@@ -464,6 +374,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rust_fzf"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,17 +443,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -580,18 +508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,12 +550,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -808,8 +718,7 @@ dependencies = [
  "auth-git2",
  "clap",
  "git2",
- "pest",
- "pest_derive",
+ "regex",
  "rust_fzf",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,8 @@ repository = "https://github.com/Pilou97/yggit"
 [dependencies]
 clap = { version = "4.4.17", features = ["derive"] }
 git2 = "0.17.2"
+regex = "1.11.1"
 auth-git2 = "0.5.3"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 rust_fzf = "0.1.1"
-pest = "2.7.3"
-pest_derive = "2.7.3"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,8 +5,7 @@ use crate::{
     git::EnhancedCommit,
 };
 use git2::Oid;
-use pest::{iterators::Pair, Parser};
-use pest_derive::Parser;
+use regex::Regex;
 
 pub fn commits_to_string(commits: Vec<EnhancedCommit<Note>>) -> String {
     let mut output = String::default();
@@ -26,7 +25,7 @@ pub fn commits_to_string(commits: Vec<EnhancedCommit<Note>>) -> String {
             {
                 output = format!("{}-> {}\n", output, branch);
             }
-            // An empty line is added so that is cleaner to differentiate the different MR
+            // An empty line is added so that it is cleaner to differentiate the different MR
             if push.is_some() {
                 output = format!("{}\n", output);
             }
@@ -34,10 +33,6 @@ pub fn commits_to_string(commits: Vec<EnhancedCommit<Note>>) -> String {
     }
     output
 }
-
-#[derive(Parser)]
-#[grammar = "parser/yggit.pest"]
-struct YggitParser;
 
 #[derive(Debug, Clone)]
 pub struct Target {
@@ -53,79 +48,90 @@ pub struct Commit {
     pub target: Option<Target>,
 }
 
-fn parse_target(pair: Pair<Rule>) -> Option<Target> {
-    let target = pair.into_inner();
-
-    let mut parsed_origin = None;
-    let mut parsed_branch = None;
-
-    for pair in target.into_iter() {
-        match pair.as_rule() {
-            Rule::origin => {
-                parsed_origin = Some(pair.as_str().to_string());
-            }
-            Rule::branch_name => {
-                parsed_branch = Some(pair.as_str().to_string());
-            }
-            _ => (),
-        }
-    }
-    let parsed_branch = parsed_branch?;
-
-    Some(Target {
-        origin: parsed_origin,
-        branch: parsed_branch,
-    })
-}
-
-fn parse_commit(pair: Pair<Rule>) -> Option<Commit> {
-    let mut commit = pair.into_inner();
-
-    let git_commit = commit.next()?;
-    let mut git_commit = git_commit.into_inner();
-
-    let hash = git_commit.next()?;
-    let hash = Oid::from_str(hash.as_str()).ok()?;
-
-    let title = git_commit.next()?;
-    let title = title.as_str();
-
-    let mut target = None;
-
-    // Optional target
-    for pair in commit {
-        if let Rule::target = pair.as_rule() {
-            target = parse_target(pair);
-        }
-    }
-
-    Some(Commit {
-        hash,
-        title: title.to_string(),
-        target,
-    })
-}
-
-fn parse_value(pair: Pair<Rule>) -> Option<Vec<Commit>> {
-    match pair.as_rule() {
-        Rule::commits => {
-            let mut commits = Vec::default();
-            for pair in pair.into_inner() {
-                let commit = parse_commit(pair)?;
-                commits.push(commit);
-            }
-            Some(commits)
-        }
-        _ => None,
-    }
-}
-
 pub fn instruction_from_string(input: String) -> Option<Vec<Commit>> {
-    let pair = YggitParser::parse(Rule::commits, &input)
-        .map_err(|err| println!("{err}"))
-        .ok()?
-        .next()?;
-    let commits = parse_value(pair)?;
+    let commit_header_re = Regex::new(r"^(?P<hash>[0-9a-fA-F]{40})\s+(?P<title>.+)$").ok()?;
+    let target_re = Regex::new(r"^->\s*(?:(?P<origin>[^:]+):)?(?P<branch>.+)$").ok()?;
+    
+    let mut commits = Vec::new();
+    let lines: Vec<&str> = input.lines().map(|line| line.trim()).collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        if line.is_empty() || line.starts_with("#") {
+            i += 1;
+            continue;
+        }
+        if let Some(caps) = commit_header_re.captures(line) {
+            let hash_str = caps.name("hash")?.as_str();
+            let title = caps.name("title")?.as_str().to_string();
+            let hash = Oid::from_str(hash_str).ok()?;
+            let mut target = None;
+            if i + 1 < lines.len() {
+                let next_line = lines[i + 1];
+                if next_line.starts_with("->") {
+                    if let Some(target_caps) = target_re.captures(next_line) {
+                        let origin = target_caps.name("origin").map(|m| m.as_str().to_string());
+                        let branch = target_caps.name("branch")?.as_str().to_string();
+                        target = Some(Target { origin, branch });
+                        i += 1;
+                    }
+                }
+            }
+            commits.push(Commit { hash, title, target });
+        }
+        i += 1;
+    }
+    if commits.is_empty() {
+        None
+    } else {
+        Some(commits)
+    }
+}
 
-    Some(commits)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use git2::Oid;
+
+    #[test]
+    fn test_parse_commit_with_target_no_colon() {
+        let input = "8c14734b80ff0ffb93caefc85553c7c5b05cca1e devinfra: New configs (#3333)\n-> d4hines/foo-bar\n";
+        let commits = instruction_from_string(input.to_string()).expect("Should parse commits");
+        assert_eq!(commits.len(), 1);
+        let commit = &commits[0];
+        let expected_hash = "8c14734b80ff0ffb93caefc85553c7c5b05cca1e";
+        assert_eq!(commit.hash.to_string(), expected_hash);
+        assert_eq!(commit.title, "devinfra: New configs (#3333)".to_string());
+        assert!(commit.target.is_some());
+        let target = commit.target.as_ref().unwrap();
+        assert_eq!(target.origin, None);
+        assert_eq!(target.branch, "d4hines/foo-bar".to_string());
+    }
+
+    #[test]
+    fn test_parse_commit_without_target() {
+        let input = "8c14734b80ff0ffb93caefc85553c7c5b05cca1e Some commit without target\n";
+        let commits = instruction_from_string(input.to_string()).expect("Should parse commits");
+        assert_eq!(commits.len(), 1);
+        let commit = &commits[0];
+        let expected_hash = "8c14734b80ff0ffb93caefc85553c7c5b05cca1e";
+        assert_eq!(commit.hash.to_string(), expected_hash);
+        assert_eq!(commit.title, "Some commit without target".to_string());
+        assert!(commit.target.is_none());
+    }
+
+    #[test]
+    fn test_parse_commit_with_target_with_colon() {
+        let input = "8c14734b80ff0ffb93caefc85553c7c5b05cca1e Feature commit with colon\n-> d4hines:foo-bar\n";
+        let commits = instruction_from_string(input.to_string()).expect("Should parse commits");
+        assert_eq!(commits.len(), 1);
+        let commit = &commits[0];
+        let expected_hash = "8c14734b80ff0ffb93caefc85553c7c5b05cca1e";
+        assert_eq!(commit.hash.to_string(), expected_hash);
+        assert_eq!(commit.title, "Feature commit with colon".to_string());
+        assert!(commit.target.is_some());
+        let target = commit.target.as_ref().unwrap();
+        assert_eq!(target.origin, Some("d4hines".to_string()));
+        assert_eq!(target.branch, "foo-bar".to_string());
+    }
 }


### PR DESCRIPTION
Remove pest and its related dependencies from Cargo.lock and Cargo.toml. Update src/parser.rs to use the regex crate along with regex-automata and regex-syntax, streamlining parsing and improving maintainability.